### PR TITLE
Making sure service is restarted if ssl config changes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -374,6 +374,7 @@ class puppetdb (
   # we have to regenerate it. 
   exec { "/usr/sbin/puppetdb-ssl-setup":
     creates => '/etc/puppetdb/ssl/keystore.jks',
+    notify  => Service['puppetdb'],
     require => Package['puppetdb'];
   }
 


### PR DESCRIPTION
Ran into a situation where if the puppet.conf file isn't written when /usr/sbin/puppetdb-ssl-setup is run, then it will fail. Adding a notify from the exec to the service ensures that if it runs successfully later on the service is restarted so the changes can come into effect automatically.
