### PR TITLE
Feature: Add the ability to turn on serving of plain http to the world

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -92,7 +92,9 @@ class puppetdb::params {
   }
 
   $port = '8080'
+  $https_port = '8081'
   $protocol = 'tcp'
+  $serve_http = false # HTTPS only by default
 
   # General Settings
   $my_class = ''

--- a/templates/jetty.ini.erb
+++ b/templates/jetty.ini.erb
@@ -1,0 +1,30 @@
+# This file is managed by puppet - manual changes WILL be overwritten on the next puppet run
+
+[jetty]
+<% if scope.lookupvar('puppetdb::bool_serve_http') -%>
+# Hostname or IP address to listen for clear-text HTTP.  Default is localhost
+host = <%= @fqdn %>
+
+# Port to listen on for clear-text HTTP.
+port = <%= scope.lookupvar('puppetdb::port') %>
+
+<% end -%>
+# The following are SSL specific settings. They can be configured
+# automatically with the tool puppetdb-ssl-setup, which is normally
+# ran during package installation.
+
+# The host or IP address to listen on for HTTPS connections
+ssl-host = <%= @fqdn %>
+
+# The port to listen on for HTTPS connections
+ssl-port = <%= scope.lookupvar('puppetdb::https_port') %>
+
+# Private key path
+ssl-key = /etc/puppetdb/ssl/private.pem
+
+# Public certificate path
+ssl-cert = /etc/puppetdb/ssl/public.pem
+
+# Certificate authority path
+ssl-ca-cert = /etc/puppetdb/ssl/ca.pem
+


### PR DESCRIPTION
I needed to be able to serve plain `http`, so I can offload the SSL to a load balancer.
There was no ability to do so in the module, so I added it in this patch.

I have tested that it applies ok, but I have not yet added the ability to turn it off again.
Perhaps I will do so later (if noone beats me to it).

Also, the SSL paths in the jetty.ini template are hardcoded (they match Ubuntu 12.04's paths) and should probably be changed to be variables.
