### PR TITLE
Version compare failed

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -388,15 +388,15 @@ class puppetdb (
   }
 
   if inline_template('<%= scope.lookupvar("::puppetdbversion")?1:0 %>') {
-    $puppetdbversion = $::puppetdbversion
+    $puppetdbversion = "${::puppetdbversion}"
   } else {
-    $puppetdbversion = 1.5
+    $puppetdbversion = '1.5'
   }
 
   # This runs while installing the package
   # but if something kills the keystore
   # we have to regenerate it. 
-  if $puppetdbversion <1.4 {
+  if versioncmp($puppetdbversion, '1.4') == -1 {
     $ssl_setup_creates = '/etc/puppetdb/ssl/keystore.jks'
   } else {
     $ssl_setup_creates = '/etc/puppetdb/ssl/private.pem'


### PR DESCRIPTION
I'm not sure if it's because of the future parser, but I got a syntax error on the '&lt;' sign. As such, I've replaced it with a call to the versioncmp() function.
