### PR TITLE
pid_file for redhat and centos;

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -76,7 +76,8 @@ class puppetdb::params {
   }
 
   $pid_file = $::operatingsystem ? {
-    default => '/var/run/puppetdb.pid',
+    /(?i:RedHat|CentOS)/  => '/var/run/puppetdb/puppetdb',
+    default               => '/var/run/puppetdb.pid',
   }
 
   $data_dir = $::operatingsystem ? {


### PR DESCRIPTION
Yes, this is default pidfile for puppetdb from official puppet repository:
# grep ^PIDFILE /etc/init.d/puppetdb

PIDFILE="/var/run/$prog/$prog"
