### PR TITLE
puppetdbversion fact: fix version extraction calling puppetdb jar.

### DIFF
--- a/lib/facter/puppetdbversion.rb
+++ b/lib/facter/puppetdbversion.rb
@@ -8,7 +8,7 @@ Facter.add("puppetdbversion") do
     if File.exists?(versionfile) and (File.stat(versionfile).mtime.to_i + (12*60*60) >= Time.now().to_i)
       %x{cat #{versionfile}}.chomp.to_f
     else
-      output = %x{/usr/bin/java -jar /usr/share/puppetdb/puppetdb.jar version 2>/dev/null | grep '^version'}
+      output = %x{/usr/bin/java -cp /usr/share/puppetdb/puppetdb.jar clojure.main -m com.puppetlabs.puppetdb.core version 2>/dev/null | grep '^version'}
       output.chomp!
       if output.length >0
         val = output.split('=')[-1]


### PR DESCRIPTION
Fix version extraction with actual version of puppetdb (not at all tested on ancient puppetdb versions and only tested on Debian Wheezy... Please also note that puppetdb asks for java 7 or the version won't be returned and the fact contains empty lines)

Old output:

```
# /usr/bin/java -jar /usr/share/puppetdb/puppetdb.jar version
Error: Could not find or load main class com.puppetlabs.puppetdb.core
```

New output:

```
# /usr/bin/java -cp /usr/share/puppetdb/puppetdb.jar clojure.main -m com.puppetlabs.puppetdb.core version
version=2.1.0
target_schema_version=23
```
